### PR TITLE
Allow uploading meta data from input pep to an output pep via registry path

### DIFF
--- a/bedboss/bedboss.py
+++ b/bedboss/bedboss.py
@@ -223,6 +223,7 @@ def insert_pep(
     no_db_commit: bool = False,
     force_overwrite: bool = False,
     upload_s3: bool = False,
+    upload_pephub: bool = False,
     pm: pypiper.PipelineManager = None,
     *args,
     **kwargs,
@@ -244,6 +245,7 @@ def insert_pep(
     :param bool no_db_commit: whether the JSON commit to the database should be skipped
     :param bool force_overwrite: whether to overwrite the existing record
     :param bool upload_s3: whether to upload to s3
+    :param bool upload_pephub: whether to push bedfiles and metadata to pephub (default: False)
     :param pypiper.PipelineManager pm: pypiper object
     :return: None
     """
@@ -295,6 +297,7 @@ def insert_pep(
             force_overwrite=force_overwrite,
             skip_qdrant=skip_qdrant,
             upload_s3=upload_s3,
+            upload_pephub=upload_pephub,
             pm=pm,
         )
         pep.samples[i].record_identifier = bed_id

--- a/bedboss/bedboss.py
+++ b/bedboss/bedboss.py
@@ -87,6 +87,7 @@ def run_all(
     open_signal_matrix: str = None,
     ensdb: str = None,
     treatment: str = None,
+    pep_sample_dict: dict = None,
     description: str = None,
     cell_type: str = None,
     other_metadata: dict = None,
@@ -117,6 +118,7 @@ def run_all(
         :param str description: a description of the bed file
     :param str open_signal_matrix: a full path to the openSignalMatrix required for the tissue [optional]
     :param str treatment: a treatment of the bed file
+    :param dict pep_sample_dict: a dict containing all attributes from the sample
     :param str cell_type: a cell type of the bed file
     :param dict other_metadata: a dictionary of other metadata to pass
     :param str ensdb: a full path to the ensdb gtf file required for genomes not in GDdata [optional]
@@ -193,6 +195,7 @@ def run_all(
         bigbed=output_bigbed,
         description=description,
         treatment=treatment,
+        pep_sample_dict=pep_sample_dict,
         cell_type=cell_type,
         other_metadata=other_metadata,
         just_db_commit=just_db_commit,
@@ -280,6 +283,7 @@ def insert_pep(
             description=pep_sample.get("description"),
             cell_type=pep_sample.get("cell_type"),
             treatment=pep_sample.get("treatment"),
+            pep_sample_dict=pep_sample.to_dict(),
             outfolder=output_folder,
             bedbase_config=bbc,
             rfg_config=rfg_config,

--- a/bedboss/bedboss.py
+++ b/bedboss/bedboss.py
@@ -95,6 +95,7 @@ def run_all(
     force_overwrite: bool = False,
     skip_qdrant: bool = True,
     upload_s3: bool = False,
+    upload_pephub: bool = False,
     pm: pypiper.PipelineManager = None,
     **kwargs,
 ) -> str:
@@ -125,6 +126,7 @@ def run_all(
     :param bool no_db_commit: whether the JSON commit to the database should be skipped (default: False)
     :param bool skip_qdrant: whether to skip qdrant indexing
     :param bool upload_s3: whether to upload to s3
+    :param bool upload_pephub: whether to push bedfiles and metadata to pephub (default: False)
     :param pypiper.PipelineManager pm: pypiper object
     :return str bed_digest: bed digest
     """
@@ -198,6 +200,7 @@ def run_all(
         force_overwrite=force_overwrite,
         skip_qdrant=skip_qdrant,
         upload_s3=upload_s3,
+        upload_pephub=upload_pephub,
         pm=pm,
     )
     return bed_digest

--- a/bedboss/bedstat/bedstat.py
+++ b/bedboss/bedstat/bedstat.py
@@ -59,7 +59,7 @@ def load_to_pephub(
     """
 
     if is_registry_path(pep_registry_path):
-        parsed_pep_list = parse_registry_path(pep_registry_path)
+        parsed_pep_dict = parse_registry_path(pep_registry_path)
 
         # Combine data into a dict for sending to pephub
         sample_data = {}
@@ -69,11 +69,12 @@ def load_to_pephub(
             # TODO Confirm this key is in the schema
             # Then update sample_data
             sample_data.update({key: value})
+
         try:
             PEPHubClient().sample.create(
-                namespace=parsed_pep_list[1],
-                name=parsed_pep_list[2],
-                tag=parsed_pep_list[4],
+                namespace=parsed_pep_dict["namespace"],
+                name=parsed_pep_dict["item"],
+                tag=parsed_pep_dict["item"],
                 sample_name=bed_digest,
                 overwrite=True,
                 sample_dict=sample_data,
@@ -169,6 +170,7 @@ def bedstat(
     """
     # TODO why are we no longer using bbconf to get the output path?
     # outfolder_stats = bbc.get_bedstat_output_path()
+
     outfolder_stats = os.path.join(outfolder, OUTPUT_FOLDER_NAME, BEDSTAT_OUTPUT)
     try:
         os.makedirs(outfolder_stats)
@@ -352,6 +354,7 @@ def bedstat(
         )
 
     if upload_pephub:
+        _LOGGER.info("UPLOADING TO PEPHUB...")
         load_to_pephub(
             pep_registry_path=BED_PEP_REGISTRY,
             bed_digest=bed_digest,

--- a/bedboss/bedstat/bedstat.py
+++ b/bedboss/bedstat/bedstat.py
@@ -124,6 +124,7 @@ def bedstat(
     open_signal_matrix: str = None,
     bigbed: str = None,
     treatment: str = None,
+    pep_sample_dict: dict = None,
     description: str = None,
     cell_type: str = None,
     other_metadata: dict = None,
@@ -153,6 +154,7 @@ def bedstat(
         not in GDdata
     :param str description: a description of the bed file
     :param str treatment: a treatment of the bed file
+    :param dict pep_sample_dict: a dict containing all attributes from the sample
     :param str cell_type: a cell type of the bed file
     :param dict other_metadata: a dictionary of other metadata to pass
     :param bool just_db_commit: whether just to commit the JSON to the database
@@ -260,6 +262,11 @@ def bedstat(
                 "cell_type": cell_type,
             }
         )
+
+        # For now, add all the *other* attributes to other_metadata
+        for key, value in pep_sample_dict.items():
+            if key not in list(other_metadata.keys()):
+                other_metadata.update({key: value})
 
         # unlist the data, since the output of regionstat.R is a dict of lists of
         # length 1 and force keys to lower to correspond with the

--- a/bedboss/bedstat/bedstat.py
+++ b/bedboss/bedstat/bedstat.py
@@ -59,7 +59,6 @@ def load_to_pephub(
     """
 
     if is_registry_path(pep_registry_path):
-
         parsed_pep_list = parse_registry_path(pep_registry_path)
 
         # Combine data into a dict for sending to pephub

--- a/bedboss/bedstat/bedstat.py
+++ b/bedboss/bedstat/bedstat.py
@@ -7,7 +7,9 @@ import bbconf
 import logging
 import pephubclient as phc
 from geniml.io import RegionSet
+from pephubclient import PEPHubClient
 from pephubclient.helpers import is_registry_path
+from ubiquerg import parse_registry_path
 
 from bedboss.const import (
     OUTPUT_FOLDER_NAME,
@@ -57,6 +59,9 @@ def load_to_pephub(
     """
 
     if is_registry_path(pep_registry_path):
+
+        parsed_pep_list = parse_registry_path(pep_registry_path)
+
         # Combine data into a dict for sending to pephub
         sample_data = {}
         sample_data.update({"sample_name": bed_digest, "genome": genome})
@@ -66,7 +71,15 @@ def load_to_pephub(
             # Then update sample_data
             sample_data.update({key: value})
         try:
-            phc.sample.add(sample_data)
+            PEPHubClient().sample.create(
+                namespace=parsed_pep_list[1],
+                name=parsed_pep_list[2],
+                tag=parsed_pep_list[4],
+                sample_name=bed_digest,
+                overwrite=True,
+                sample_dict=sample_data,
+            )
+
         except Exception as e:  # Need more specific exception
             _LOGGER.warning(f"Failed to upload BEDFILE to Bedbase: See {e}")
     else:

--- a/bedboss/cli.py
+++ b/bedboss/cli.py
@@ -166,6 +166,11 @@ def build_argparser() -> ArgumentParser:
         action="store_true",
         help="whether to skip qdrant indexing",
     )
+    sub_all.add_argument(
+        "--upload-pephub",
+        action="store_true",
+        help="upload to pephub",
+    )
 
     # all-pep
     sub_all_pep.add_argument(
@@ -244,6 +249,11 @@ def build_argparser() -> ArgumentParser:
         help="Weather to upload bed, bigbed, and statistics to s3. "
         "Before uploading you have to set up all necessury env vars: "
         "AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, and AWS_ENDPOINT_URL. [Default: False]",
+    )
+    sub_all_pep.add_argument(
+        "--upload-pephub",
+        action="store_true",
+        help="upload to pephub",
     )
 
     # bed_qc


### PR DESCRIPTION
Allow uploading meta data from input pep to an output pep via registry paths.

Currently, the output PEP for all of this processing is:
https://pephub.databio.org/databio/allbeds?tag=bedbase

command examples:
```
bedboss insert --bedbase-config bedboss_config.yaml --pep donaldcampbelljr/test_minimal_bedboss:samples --output-folder ./bedbossoutput --skip-qdrant --upload-pephub
```