### PR TITLE
Output tiered Parquet files for UMAP visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.DS_Store
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+test/sam/
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/bedboss/cli.py
+++ b/bedboss/cli.py
@@ -685,6 +685,10 @@ def download_umap(
         "umap",
         help="Dimensionality reduction method to use. Options: 'umap', 'pca', or 'tsne'. To use UMAP, 'umap-learn' package must be installed.",
     ),
+    save_parquet: bool = typer.Option(
+        True,
+        help="Whether to save Parquet tier files alongside JSON",
+    ),
 ):
     from bedboss.scripts.make_umap import get_embeddings
 
@@ -697,6 +701,7 @@ def download_umap(
         top_assays=top_assays,
         top_cell_lines=top_cell_lines,
         method=method,
+        save_parquet=save_parquet,
     )
 
 
@@ -718,29 +723,9 @@ def update_umap_metadata(
         help="Path to existing geometry Parquet (to read bed IDs). If not provided, fetches IDs from Qdrant.",
     ),
 ):
-    import pandas as pd
-    from bbconf import BedBaseAgent
-    from bedboss.scripts.make_umap import (
-        fetch_data,
-        fetch_db_metadata,
-        save_parquet_tiers,
-    )
+    from bedboss.scripts.make_umap import update_umap_metadata as _update
 
-    agent = BedBaseAgent(config=config)
-
-    if geometry:
-        geo_df = pd.read_parquet(geometry)
-        bed_ids = list(geo_df["id"])
-        # Fetch Qdrant data to get payload metadata
-        qdrant_df = fetch_data(agent=agent)
-        # Filter to IDs in geometry
-        qdrant_df = qdrant_df.loc[qdrant_df.index.isin(bed_ids)]
-    else:
-        qdrant_df = fetch_data(agent=agent)
-        bed_ids = list(qdrant_df.index)
-
-    db_meta = fetch_db_metadata(agent, bed_ids)
-    save_parquet_tiers(qdrant_df, db_meta, output_dir)
+    _update(bbconf=config, output_dir=output_dir, geometry=geometry)
 
 
 @app.command(help="Check installed R packages")

--- a/bedboss/cli.py
+++ b/bedboss/cli.py
@@ -700,6 +700,45 @@ def download_umap(
     )
 
 
+@app.command(help="Update UMAP metadata Parquet tiers without regenerating geometry")
+def update_umap_metadata(
+    config: str = typer.Option(
+        ...,
+        help="Path to the bedbase config file",
+        exists=True,
+        file_okay=True,
+        readable=True,
+    ),
+    output_dir: str = typer.Option(
+        ...,
+        help="Directory to write Parquet tier files",
+    ),
+    geometry: str = typer.Option(
+        None,
+        help="Path to existing geometry Parquet (to read bed IDs). If not provided, fetches IDs from Qdrant.",
+    ),
+):
+    import pandas as pd
+    from bbconf import BedBaseAgent
+    from bedboss.scripts.make_umap import fetch_data, fetch_db_metadata, save_parquet_tiers
+
+    agent = BedBaseAgent(config=config)
+
+    if geometry:
+        geo_df = pd.read_parquet(geometry)
+        bed_ids = list(geo_df["id"])
+        # Fetch Qdrant data to get payload metadata
+        qdrant_df = fetch_data(agent=agent)
+        # Filter to IDs in geometry
+        qdrant_df = qdrant_df.loc[qdrant_df.index.isin(bed_ids)]
+    else:
+        qdrant_df = fetch_data(agent=agent)
+        bed_ids = list(qdrant_df.index)
+
+    db_meta = fetch_db_metadata(agent, bed_ids)
+    save_parquet_tiers(qdrant_df, db_meta, output_dir)
+
+
 @app.command(help="Check installed R packages")
 def check_requirements():
     from bedboss.bedboss import requirements_check

--- a/bedboss/cli.py
+++ b/bedboss/cli.py
@@ -720,7 +720,11 @@ def update_umap_metadata(
 ):
     import pandas as pd
     from bbconf import BedBaseAgent
-    from bedboss.scripts.make_umap import fetch_data, fetch_db_metadata, save_parquet_tiers
+    from bedboss.scripts.make_umap import (
+        fetch_data,
+        fetch_db_metadata,
+        save_parquet_tiers,
+    )
 
     agent = BedBaseAgent(config=config)
 

--- a/bedboss/const.py
+++ b/bedboss/const.py
@@ -38,3 +38,35 @@ REFGENIE_ENV_VAR = "REFGENIE"
 DEFAULT_REFGENIE_PATH = os.path.join(HOME_PATH, ".refgenie")
 
 BED_PEP_REGISTRY = "databio/allbeds:bedbase"
+
+# UMAP Parquet tier column definitions
+DB_QUERY_BATCH_SIZE = 5000
+
+TIER1_COLUMNS = [
+    "id",
+    "name",
+    "description",
+    "assay",
+    "target",
+    "cell_line",
+    "cell_type",
+    "tissue",
+    "number_of_regions",
+    "mean_region_width",
+    "gc_content",
+]
+
+TIER2_COLUMNS = [
+    "id",
+    "treatment",
+    "antibody",
+    "species_name",
+    "genome_alias",
+    "bed_compliance",
+    "data_format",
+    "median_tss_dist",
+    "library_source",
+    "global_sample_id",
+    "global_experiment_id",
+    "original_file_name",
+]

--- a/bedboss/scripts/make_umap.py
+++ b/bedboss/scripts/make_umap.py
@@ -114,25 +114,13 @@ def fetch_db_metadata(agent: BedBaseAgent, bed_ids: list[str]) -> pd.DataFrame:
         ):
             row = {"id": bed_obj.id}
 
-            # Stats
+            # Stats (tier 1 region characteristics + tier 2 TSS distance)
             if bed_obj.stats:
                 stats = bed_obj.stats
                 row["number_of_regions"] = stats.number_of_regions
                 row["mean_region_width"] = stats.mean_region_width
                 row["gc_content"] = stats.gc_content
                 row["median_tss_dist"] = stats.median_tss_dist
-                row["exon_frequency"] = stats.exon_frequency
-                row["exon_percentage"] = stats.exon_percentage
-                row["intron_frequency"] = stats.intron_frequency
-                row["intron_percentage"] = stats.intron_percentage
-                row["intergenic_frequency"] = stats.intergenic_frequency
-                row["intergenic_percentage"] = stats.intergenic_percentage
-                row["promotercore_frequency"] = stats.promotercore_frequency
-                row["promotercore_percentage"] = stats.promotercore_percentage
-                row["fiveutr_frequency"] = stats.fiveutr_frequency
-                row["fiveutr_percentage"] = stats.fiveutr_percentage
-                row["threeutr_frequency"] = stats.threeutr_frequency
-                row["threeutr_percentage"] = stats.threeutr_percentage
                 row["promoterprox_frequency"] = stats.promoterprox_frequency
                 row["promoterprox_percentage"] = stats.promoterprox_percentage
 
@@ -143,9 +131,7 @@ def fetch_db_metadata(agent: BedBaseAgent, bed_ids: list[str]) -> pd.DataFrame:
                 row["library_source"] = anno.library_source
                 row["original_file_name"] = anno.original_file_name
                 row["global_sample_id"] = (
-                    ";".join(anno.global_sample_id)
-                    if anno.global_sample_id
-                    else None
+                    ";".join(anno.global_sample_id) if anno.global_sample_id else None
                 )
                 row["global_experiment_id"] = (
                     ";".join(anno.global_experiment_id)
@@ -241,47 +227,50 @@ def save_parquet_tiers(
     for col in ["x", "y", "z"]:
         if col in geometry.columns:
             geometry[col] = geometry[col].round(2).astype("float32")
-    geometry.to_parquet(
-        os.path.join(output_dir, "hg38_geometry.parquet"), index=False
-    )
+    geometry.to_parquet(os.path.join(output_dir, "hg38_geometry.parquet"), index=False)
     _LOGGER.info(f"Geometry: {len(geometry)} rows")
 
     # --- Tier 1: Core metadata ---
-    t1_cols = ["id", "name", "description", "assay", "target", "cell_line",
-               "cell_type", "tissue", "number_of_regions", "mean_region_width",
-               "gc_content"]
+    t1_cols = [
+        "id",
+        "name",
+        "description",
+        "assay",
+        "target",
+        "cell_line",
+        "cell_type",
+        "tissue",
+        "number_of_regions",
+        "mean_region_width",
+        "gc_content",
+    ]
     t1 = combined[[c for c in t1_cols if c in combined.columns]].copy()
     t1 = t1.fillna("")
-    t1.to_parquet(
-        os.path.join(output_dir, "hg38_meta_t1.parquet"), index=False
-    )
+    t1.to_parquet(os.path.join(output_dir, "hg38_meta_t1.parquet"), index=False)
     _LOGGER.info(f"Tier 1: {len(t1)} rows, {len(t1.columns)} columns")
 
     # --- Tier 2: Extended annotation ---
-    t2_cols = ["id", "treatment", "antibody", "species_name", "genome_alias",
-               "bed_compliance", "data_format", "median_tss_dist",
-               "library_source", "global_sample_id", "global_experiment_id",
-               "original_file_name"]
+    t2_cols = [
+        "id",
+        "treatment",
+        "antibody",
+        "species_name",
+        "genome_alias",
+        "bed_compliance",
+        "data_format",
+        "median_tss_dist",
+        "library_source",
+        "global_sample_id",
+        "global_experiment_id",
+        "original_file_name",
+    ]
     t2 = combined[[c for c in t2_cols if c in combined.columns]].copy()
     t2 = t2.fillna("")
-    t2.to_parquet(
-        os.path.join(output_dir, "hg38_meta_t2.parquet"), index=False
-    )
+    t2.to_parquet(os.path.join(output_dir, "hg38_meta_t2.parquet"), index=False)
     _LOGGER.info(f"Tier 2: {len(t2)} rows, {len(t2.columns)} columns")
 
-    # --- Tier 3: Genomic partitions ---
-    t3_cols = ["id", "exon_frequency", "exon_percentage",
-               "intron_frequency", "intron_percentage",
-               "intergenic_frequency", "intergenic_percentage",
-               "promotercore_frequency", "promotercore_percentage",
-               "fiveutr_frequency", "fiveutr_percentage",
-               "threeutr_frequency", "threeutr_percentage",
-               "promoterprox_frequency", "promoterprox_percentage"]
-    t3 = combined[[c for c in t3_cols if c in combined.columns]].copy()
-    t3.to_parquet(
-        os.path.join(output_dir, "hg38_meta_t3.parquet"), index=False
-    )
-    _LOGGER.info(f"Tier 3: {len(t3)} rows, {len(t3.columns)} columns")
+    # Tier 3 reserved for future analysis results (gtars genomic distributions,
+    # enrichment profiles, embedding quality scores). Not generated in this version.
 
 
 def create_umap(

--- a/bedboss/scripts/make_umap.py
+++ b/bedboss/scripts/make_umap.py
@@ -19,7 +19,7 @@ from functools import lru_cache
 import joblib
 from bbconf import BedBaseAgent
 from bbconf.db_utils import Bed, BedMetadata, BedStats
-from sqlalchemy.orm import Session, joinedload
+from sqlalchemy.orm import Session, joinedload, load_only
 import json
 
 from bedboss.const import PKG_NAME
@@ -64,11 +64,18 @@ def fetch_data(agent: BedBaseAgent) -> pd.DataFrame:
 
     _LOGGER.info("Fetching data from Qdrant...")
 
-    client = QdrantClient(
-        host=agent.config.config.qdrant.host,
-        port=6333,
-        api_key=agent.config.config.qdrant.api_key,
-    )
+    qdrant_host = agent.config.config.qdrant.host
+    if qdrant_host.startswith("http://") or qdrant_host.startswith("https://"):
+        client = QdrantClient(
+            url=qdrant_host,
+            api_key=agent.config.config.qdrant.api_key,
+        )
+    else:
+        client = QdrantClient(
+            host=qdrant_host,
+            port=6333,
+            api_key=agent.config.config.qdrant.api_key,
+        )
 
     points = []
     next_offset = 0
@@ -112,7 +119,15 @@ def fetch_db_metadata(agent: BedBaseAgent, bed_ids: list[str]) -> pd.DataFrame:
             batch = bed_ids[i : i + batch_size]
             for bed_obj in (
                 session.query(Bed)
-                .options(joinedload(Bed.stats), joinedload(Bed.annotations))
+                .options(
+                    joinedload(Bed.stats).load_only(
+                        BedStats.number_of_regions,
+                        BedStats.mean_region_width,
+                        BedStats.gc_content,
+                        BedStats.median_tss_dist,
+                    ),
+                    joinedload(Bed.annotations),
+                )
                 .filter(Bed.id.in_(batch))
                 .all()
             ):
@@ -241,16 +256,21 @@ def save_parquet_tiers(
     else:
         combined = df
 
-    # --- Geometry ---
-    coord_cols = ["id", "x", "y"]
-    if "z" in combined.columns:
-        coord_cols.append("z")
-    geometry = combined[coord_cols].copy()
-    for col in ["x", "y", "z"]:
-        if col in geometry.columns:
-            geometry[col] = geometry[col].round(2).astype("float32")
-    geometry.to_parquet(os.path.join(output_dir, "hg38_geometry.parquet"), index=False)
-    _LOGGER.info(f"Geometry: {len(geometry)} rows")
+    # --- Geometry (only when coordinates are present) ---
+    if "x" in combined.columns and "y" in combined.columns:
+        coord_cols = ["id", "x", "y"]
+        if "z" in combined.columns:
+            coord_cols.append("z")
+        geometry = combined[coord_cols].copy()
+        for col in ["x", "y", "z"]:
+            if col in geometry.columns:
+                geometry[col] = geometry[col].round(2).astype("float32")
+        geometry.to_parquet(
+            os.path.join(output_dir, "hg38_geometry.parquet"), index=False
+        )
+        _LOGGER.info(f"Geometry: {len(geometry)} rows")
+    else:
+        _LOGGER.info("No coordinates found, skipping geometry file.")
 
     # --- Tier 1: Core metadata ---
     t1_cols = [
@@ -267,7 +287,8 @@ def save_parquet_tiers(
         "gc_content",
     ]
     t1 = combined[[c for c in t1_cols if c in combined.columns]].copy()
-    t1 = t1.fillna("")
+    str_cols = t1.select_dtypes(include="object").columns
+    t1[str_cols] = t1[str_cols].fillna("")
     t1.to_parquet(os.path.join(output_dir, "hg38_meta_t1.parquet"), index=False)
     _LOGGER.info(f"Tier 1: {len(t1)} rows, {len(t1.columns)} columns")
 
@@ -287,7 +308,8 @@ def save_parquet_tiers(
         "original_file_name",
     ]
     t2 = combined[[c for c in t2_cols if c in combined.columns]].copy()
-    t2 = t2.fillna("")
+    str_cols = t2.select_dtypes(include="object").columns
+    t2[str_cols] = t2[str_cols].fillna("")
     t2.to_parquet(os.path.join(output_dir, "hg38_meta_t2.parquet"), index=False)
     _LOGGER.info(f"Tier 2: {len(t2)} rows, {len(t2.columns)} columns")
 

--- a/bedboss/scripts/make_umap.py
+++ b/bedboss/scripts/make_umap.py
@@ -18,6 +18,8 @@ from functools import lru_cache
 
 import joblib
 from bbconf import BedBaseAgent
+from bbconf.db_utils import Bed, BedMetadata, BedStats
+from sqlalchemy.orm import Session, joinedload
 import json
 
 from bedboss.const import PKG_NAME
@@ -49,8 +51,6 @@ def save_umap_model(umap_model: Union[UMAP, PCA, TSNE], model_path: str) -> None
     _LOGGER.info(f"Model saved to {model_path}")
 
 
-# @lru_cache()
-# TODO: can we make this function cached, without using credentials as part of the cache key?
 def fetch_data(agent: BedBaseAgent) -> pd.DataFrame:
     """
     Fetch data from Qdrant collection and return it as a DataFrame.
@@ -95,31 +95,88 @@ def fetch_data(agent: BedBaseAgent) -> pd.DataFrame:
     return merged
 
 
+def fetch_db_metadata(agent: BedBaseAgent, bed_ids: list[str]) -> pd.DataFrame:
+    """
+    Fetch bed_stats and annotation metadata from PostgreSQL for the given bed IDs.
+
+    Returns a DataFrame indexed by bed ID with stats and annotation columns.
+    """
+    _LOGGER.info(f"Fetching DB metadata for {len(bed_ids)} beds...")
+
+    rows = []
+    with Session(agent.config.db_engine.engine) as session:
+        # Batch query to avoid N+1
+        for bed_obj in (
+            session.query(Bed)
+            .options(joinedload(Bed.stats), joinedload(Bed.annotations))
+            .filter(Bed.id.in_(bed_ids))
+            .all()
+        ):
+            row = {"id": bed_obj.id}
+
+            # Stats
+            if bed_obj.stats:
+                stats = bed_obj.stats
+                row["number_of_regions"] = stats.number_of_regions
+                row["mean_region_width"] = stats.mean_region_width
+                row["gc_content"] = stats.gc_content
+                row["median_tss_dist"] = stats.median_tss_dist
+                row["exon_frequency"] = stats.exon_frequency
+                row["exon_percentage"] = stats.exon_percentage
+                row["intron_frequency"] = stats.intron_frequency
+                row["intron_percentage"] = stats.intron_percentage
+                row["intergenic_frequency"] = stats.intergenic_frequency
+                row["intergenic_percentage"] = stats.intergenic_percentage
+                row["promotercore_frequency"] = stats.promotercore_frequency
+                row["promotercore_percentage"] = stats.promotercore_percentage
+                row["fiveutr_frequency"] = stats.fiveutr_frequency
+                row["fiveutr_percentage"] = stats.fiveutr_percentage
+                row["threeutr_frequency"] = stats.threeutr_frequency
+                row["threeutr_percentage"] = stats.threeutr_percentage
+                row["promoterprox_frequency"] = stats.promoterprox_frequency
+                row["promoterprox_percentage"] = stats.promoterprox_percentage
+
+            # Annotation (tier 2 fields not in Qdrant payload)
+            if bed_obj.annotations:
+                anno = bed_obj.annotations
+                row["antibody"] = anno.antibody
+                row["library_source"] = anno.library_source
+                row["original_file_name"] = anno.original_file_name
+                row["global_sample_id"] = (
+                    ";".join(anno.global_sample_id)
+                    if anno.global_sample_id
+                    else None
+                )
+                row["global_experiment_id"] = (
+                    ";".join(anno.global_experiment_id)
+                    if anno.global_experiment_id
+                    else None
+                )
+
+            # Classification (from Bed table)
+            row["bed_compliance"] = bed_obj.bed_compliance
+            row["data_format"] = bed_obj.data_format
+
+            rows.append(row)
+
+    df = pd.DataFrame(rows)
+    if not df.empty:
+        df = df.set_index("id")
+    _LOGGER.info(f"Fetched DB metadata for {len(df)} beds.")
+    return df
+
+
 def save_df_as_json(df: pd.DataFrame, output_path: str) -> None:
     """
-    Save a DataFrame as a JSON file in the specified format.
-    It includes the following columns:
-    - x, y, z (coordinates)
-    - id (string identifier)
-    - name (string)
-    - description (string)
-    - assay (string)
-    - cell_line (string)
-
-    :param df: DataFrame to save
-    :param output_path: Path to save the JSON file
-    :return: None
-
+    Save a DataFrame as a JSON file in the legacy format.
+    Kept for backward compatibility during migration.
     """
-    # Select the required columns
     columns_to_include = [
         "x",
         "y",
         "id",
         "name",
         "description",
-        # "data_format",
-        # "bed_compliance",
         "assay",
         "cell_line",
     ]
@@ -128,29 +185,103 @@ def save_df_as_json(df: pd.DataFrame, output_path: str) -> None:
         columns_to_include.insert(2, "z")
 
     output_path = os.path.abspath(output_path)
-    (f"Saving DataFrame as JSON to {output_path}")
 
-    df.loc[:, "id"] = df.index.astype(str)  # Ensure 'id' is a string
+    df.loc[:, "id"] = df.index.astype(str)
     df = df.fillna("")
 
     coord_cols = [c for c in ["x", "y", "z"] if c in df.columns]
 
-    # Create the nodes structure
     nodes = df[columns_to_include].to_dict(orient="records")
     for node in nodes:
         for col in coord_cols:
             if col in node:
                 node[col] = round(float(node[col]), 2)
 
-    # Create the final JSON structure
     json_data = {"nodes": nodes, "links": []}
 
-    # Save to a JSON file
     output_path = f"{output_path}_{python_version}.json"
     with open(output_path, "w") as json_file:
         json.dump(json_data, json_file, indent=4)
 
-    _LOGGER.info(f"Data saved to {output_path} successfully.")
+    _LOGGER.info(f"Legacy JSON saved to {output_path}")
+
+
+def save_parquet_tiers(
+    df: pd.DataFrame,
+    db_meta: pd.DataFrame,
+    output_dir: str,
+) -> None:
+    """
+    Save UMAP data as tiered Parquet files.
+
+    Produces:
+      - hg38_geometry.parquet  (x, y, id)
+      - hg38_meta_t1.parquet   (core biological annotation + region stats)
+      - hg38_meta_t2.parquet   (extended annotation)
+      - hg38_meta_t3.parquet   (genomic partition frequencies)
+    """
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Ensure id is a column (not just index)
+    if "id" not in df.columns:
+        df = df.copy()
+        df["id"] = df.index.astype(str)
+
+    # Join DB metadata
+    if not db_meta.empty:
+        combined = df.join(db_meta, how="left", rsuffix="_db")
+    else:
+        combined = df
+
+    # --- Geometry ---
+    coord_cols = ["id", "x", "y"]
+    if "z" in combined.columns:
+        coord_cols.append("z")
+    geometry = combined[coord_cols].copy()
+    for col in ["x", "y", "z"]:
+        if col in geometry.columns:
+            geometry[col] = geometry[col].round(2).astype("float32")
+    geometry.to_parquet(
+        os.path.join(output_dir, "hg38_geometry.parquet"), index=False
+    )
+    _LOGGER.info(f"Geometry: {len(geometry)} rows")
+
+    # --- Tier 1: Core metadata ---
+    t1_cols = ["id", "name", "description", "assay", "target", "cell_line",
+               "cell_type", "tissue", "number_of_regions", "mean_region_width",
+               "gc_content"]
+    t1 = combined[[c for c in t1_cols if c in combined.columns]].copy()
+    t1 = t1.fillna("")
+    t1.to_parquet(
+        os.path.join(output_dir, "hg38_meta_t1.parquet"), index=False
+    )
+    _LOGGER.info(f"Tier 1: {len(t1)} rows, {len(t1.columns)} columns")
+
+    # --- Tier 2: Extended annotation ---
+    t2_cols = ["id", "treatment", "antibody", "species_name", "genome_alias",
+               "bed_compliance", "data_format", "median_tss_dist",
+               "library_source", "global_sample_id", "global_experiment_id",
+               "original_file_name"]
+    t2 = combined[[c for c in t2_cols if c in combined.columns]].copy()
+    t2 = t2.fillna("")
+    t2.to_parquet(
+        os.path.join(output_dir, "hg38_meta_t2.parquet"), index=False
+    )
+    _LOGGER.info(f"Tier 2: {len(t2)} rows, {len(t2.columns)} columns")
+
+    # --- Tier 3: Genomic partitions ---
+    t3_cols = ["id", "exon_frequency", "exon_percentage",
+               "intron_frequency", "intron_percentage",
+               "intergenic_frequency", "intergenic_percentage",
+               "promotercore_frequency", "promotercore_percentage",
+               "fiveutr_frequency", "fiveutr_percentage",
+               "threeutr_frequency", "threeutr_percentage",
+               "promoterprox_frequency", "promoterprox_percentage"]
+    t3 = combined[[c for c in t3_cols if c in combined.columns]].copy()
+    t3.to_parquet(
+        os.path.join(output_dir, "hg38_meta_t3.parquet"), index=False
+    )
+    _LOGGER.info(f"Tier 3: {len(t3)} rows, {len(t3.columns)} columns")
 
 
 def create_umap(
@@ -317,7 +448,6 @@ def get_embeddings(
 
     if output_file.endswith(".json"):
         output_file = output_file[:-5]
-        # output_file += ".json"
     os.makedirs(os.path.dirname(output_file), exist_ok=True)
 
     CELL_LINE = "cell_line"
@@ -325,35 +455,6 @@ def get_embeddings(
 
     return_df = merged.copy()
 
-    ##############################################################
-    ######## Option 1 ############################################
-    ######### Remove empty/None cell lines and assays ############
-    ##############################################################
-
-    # # Select top cell lines available in the dataset
-    # if top_cell_lines is not None:
-    #     top_cell_lines_list = [
-    #         x
-    #         for x in merged[CELL_LINE].value_counts().nlargest(top_cell_lines).index
-    #         if x is not None and x != ""
-    #     ]
-    #
-    #     return_df = return_df[return_df[CELL_LINE].isin(top_cell_lines_list)]
-    #
-    # # Select top assays available in the dataset
-    # if top_assays is not None:
-    #     top_assays_list = [
-    #         x
-    #         for x in merged[ASSAY].value_counts().nlargest(top_assays).index
-    #         if x is not None and x != ""
-    #     ]
-    #
-    #     return_df = return_df[return_df[ASSAY].isin(top_assays_list)]
-
-    ################################################################################
-    ######################### Option 2 #############################################
-    ## Label empty/None cell lines and assays as "na" instead of removing them #####
-    ################################################################################
     na_name = "UNKNOWN"
 
     return_df[CELL_LINE] = return_df[CELL_LINE].fillna(na_name).replace("", na_name)
@@ -374,8 +475,6 @@ def get_embeddings(
         )
         return_df = return_df[return_df[ASSAY].isin(top_assays_list)]
 
-    ###############################################################################
-
     umap_return = create_umap(
         return_df,
         n_components=n_components,
@@ -383,11 +482,16 @@ def get_embeddings(
         label_column=plot_label,
         method=method,
     )
+
+    # Legacy JSON output
     save_df_as_json(umap_return.dataframe, output_file)
 
+    # Parquet tiered output
+    parquet_dir = os.path.dirname(os.path.abspath(output_file))
+    db_meta = fetch_db_metadata(agent, list(umap_return.dataframe.index))
+    save_parquet_tiers(umap_return.dataframe, db_meta, parquet_dir)
+
     if save_model:
-        ## controls the random initialization and stochastic optimization during UMAP fitting. But removing, because it causes issues during saving/loading
-        ## I am removing it here, but it should be set later to the same value (42)
         if method == "umap":
             umap_return.model.random_state = None
         save_umap_model(

--- a/bedboss/scripts/make_umap.py
+++ b/bedboss/scripts/make_umap.py
@@ -106,46 +106,48 @@ def fetch_db_metadata(agent: BedBaseAgent, bed_ids: list[str]) -> pd.DataFrame:
     _LOGGER.info(f"Fetching DB metadata for {len(bed_ids)} beds...")
 
     rows = []
+    batch_size = 5000
     with Session(agent.config.db_engine.engine) as session:
-        # Batch query to avoid N+1
-        for bed_obj in (
-            session.query(Bed)
-            .options(joinedload(Bed.stats), joinedload(Bed.annotations))
-            .filter(Bed.id.in_(bed_ids))
-            .all()
-        ):
-            row = {"id": bed_obj.id}
+        for i in range(0, len(bed_ids), batch_size):
+            batch = bed_ids[i : i + batch_size]
+            for bed_obj in (
+                session.query(Bed)
+                .options(joinedload(Bed.stats), joinedload(Bed.annotations))
+                .filter(Bed.id.in_(batch))
+                .all()
+            ):
+                row = {"id": bed_obj.id}
 
-            # Stats (tier 1 region characteristics + tier 2 TSS distance)
-            if bed_obj.stats:
-                stats = bed_obj.stats
-                row["number_of_regions"] = stats.number_of_regions
-                row["mean_region_width"] = stats.mean_region_width
-                row["gc_content"] = stats.gc_content
-                row["median_tss_dist"] = stats.median_tss_dist
-                row["promoterprox_frequency"] = stats.promoterprox_frequency
-                row["promoterprox_percentage"] = stats.promoterprox_percentage
+                # Stats (tier 1 region characteristics + tier 2 TSS distance)
+                if bed_obj.stats:
+                    stats = bed_obj.stats
+                    row["number_of_regions"] = stats.number_of_regions
+                    row["mean_region_width"] = stats.mean_region_width
+                    row["gc_content"] = stats.gc_content
+                    row["median_tss_dist"] = stats.median_tss_dist
 
-            # Annotation (tier 2 fields not in Qdrant payload)
-            if bed_obj.annotations:
-                anno = bed_obj.annotations
-                row["antibody"] = anno.antibody
-                row["library_source"] = anno.library_source
-                row["original_file_name"] = anno.original_file_name
-                row["global_sample_id"] = (
-                    ";".join(anno.global_sample_id) if anno.global_sample_id else None
-                )
-                row["global_experiment_id"] = (
-                    ";".join(anno.global_experiment_id)
-                    if anno.global_experiment_id
-                    else None
-                )
+                # Annotation (tier 2 fields not in Qdrant payload)
+                if bed_obj.annotations:
+                    anno = bed_obj.annotations
+                    row["antibody"] = anno.antibody
+                    row["library_source"] = anno.library_source
+                    row["original_file_name"] = anno.original_file_name
+                    row["global_sample_id"] = (
+                        ";".join(anno.global_sample_id)
+                        if anno.global_sample_id
+                        else None
+                    )
+                    row["global_experiment_id"] = (
+                        ";".join(anno.global_experiment_id)
+                        if anno.global_experiment_id
+                        else None
+                    )
 
-            # Classification (from Bed table)
-            row["bed_compliance"] = bed_obj.bed_compliance
-            row["data_format"] = bed_obj.data_format
+                # Classification (from Bed table)
+                row["bed_compliance"] = bed_obj.bed_compliance
+                row["data_format"] = bed_obj.data_format
 
-            rows.append(row)
+                rows.append(row)
 
     df = pd.DataFrame(rows)
     if not df.empty:
@@ -529,7 +531,13 @@ def get_embeddings(
 
     # Parquet tiered output
     parquet_dir = os.path.dirname(os.path.abspath(output_file))
-    db_meta = fetch_db_metadata(agent, list(umap_return.dataframe.index))
+    try:
+        db_meta = fetch_db_metadata(agent, list(umap_return.dataframe.index))
+    except Exception as e:
+        _LOGGER.warning(
+            f"Failed to fetch DB metadata, Parquet tiers will lack stats/annotation: {e}"
+        )
+        db_meta = pd.DataFrame()
     save_parquet_tiers(umap_return.dataframe, db_meta, parquet_dir)
 
     if save_model:

--- a/bedboss/scripts/make_umap.py
+++ b/bedboss/scripts/make_umap.py
@@ -51,6 +51,8 @@ def save_umap_model(umap_model: Union[UMAP, PCA, TSNE], model_path: str) -> None
     _LOGGER.info(f"Model saved to {model_path}")
 
 
+# @lru_cache()
+# TODO: can we make this function cached, without using credentials as part of the cache key?
 def fetch_data(agent: BedBaseAgent) -> pd.DataFrame:
     """
     Fetch data from Qdrant collection and return it as a DataFrame.
@@ -154,15 +156,29 @@ def fetch_db_metadata(agent: BedBaseAgent, bed_ids: list[str]) -> pd.DataFrame:
 
 def save_df_as_json(df: pd.DataFrame, output_path: str) -> None:
     """
-    Save a DataFrame as a JSON file in the legacy format.
-    Kept for backward compatibility during migration.
+    Save a DataFrame as a JSON file in the specified format.
+    It includes the following columns:
+    - x, y, z (coordinates)
+    - id (string identifier)
+    - name (string)
+    - description (string)
+    - assay (string)
+    - cell_line (string)
+
+    :param df: DataFrame to save
+    :param output_path: Path to save the JSON file
+    :return: None
+
     """
+    # Select the required columns
     columns_to_include = [
         "x",
         "y",
         "id",
         "name",
         "description",
+        # "data_format",
+        # "bed_compliance",
         "assay",
         "cell_line",
     ]
@@ -171,25 +187,29 @@ def save_df_as_json(df: pd.DataFrame, output_path: str) -> None:
         columns_to_include.insert(2, "z")
 
     output_path = os.path.abspath(output_path)
+    (f"Saving DataFrame as JSON to {output_path}")
 
-    df.loc[:, "id"] = df.index.astype(str)
+    df.loc[:, "id"] = df.index.astype(str)  # Ensure 'id' is a string
     df = df.fillna("")
 
     coord_cols = [c for c in ["x", "y", "z"] if c in df.columns]
 
+    # Create the nodes structure
     nodes = df[columns_to_include].to_dict(orient="records")
     for node in nodes:
         for col in coord_cols:
             if col in node:
                 node[col] = round(float(node[col]), 2)
 
+    # Create the final JSON structure
     json_data = {"nodes": nodes, "links": []}
 
+    # Save to a JSON file
     output_path = f"{output_path}_{python_version}.json"
     with open(output_path, "w") as json_file:
         json.dump(json_data, json_file, indent=4)
 
-    _LOGGER.info(f"Legacy JSON saved to {output_path}")
+    _LOGGER.info(f"Data saved to {output_path} successfully.")
 
 
 def save_parquet_tiers(
@@ -437,6 +457,7 @@ def get_embeddings(
 
     if output_file.endswith(".json"):
         output_file = output_file[:-5]
+        # output_file += ".json"
     os.makedirs(os.path.dirname(output_file), exist_ok=True)
 
     CELL_LINE = "cell_line"
@@ -444,6 +465,35 @@ def get_embeddings(
 
     return_df = merged.copy()
 
+    ##############################################################
+    ######## Option 1 ############################################
+    ######### Remove empty/None cell lines and assays ############
+    ##############################################################
+
+    # # Select top cell lines available in the dataset
+    # if top_cell_lines is not None:
+    #     top_cell_lines_list = [
+    #         x
+    #         for x in merged[CELL_LINE].value_counts().nlargest(top_cell_lines).index
+    #         if x is not None and x != ""
+    #     ]
+    #
+    #     return_df = return_df[return_df[CELL_LINE].isin(top_cell_lines_list)]
+    #
+    # # Select top assays available in the dataset
+    # if top_assays is not None:
+    #     top_assays_list = [
+    #         x
+    #         for x in merged[ASSAY].value_counts().nlargest(top_assays).index
+    #         if x is not None and x != ""
+    #     ]
+    #
+    #     return_df = return_df[return_df[ASSAY].isin(top_assays_list)]
+
+    ################################################################################
+    ######################### Option 2 #############################################
+    ## Label empty/None cell lines and assays as "na" instead of removing them #####
+    ################################################################################
     na_name = "UNKNOWN"
 
     return_df[CELL_LINE] = return_df[CELL_LINE].fillna(na_name).replace("", na_name)
@@ -464,6 +514,8 @@ def get_embeddings(
         )
         return_df = return_df[return_df[ASSAY].isin(top_assays_list)]
 
+    ###############################################################################
+
     umap_return = create_umap(
         return_df,
         n_components=n_components,
@@ -481,6 +533,8 @@ def get_embeddings(
     save_parquet_tiers(umap_return.dataframe, db_meta, parquet_dir)
 
     if save_model:
+        ## controls the random initialization and stochastic optimization during UMAP fitting. But removing, because it causes issues during saving/loading
+        ## I am removing it here, but it should be set later to the same value (42)
         if method == "umap":
             umap_return.model.random_state = None
         save_umap_model(

--- a/bedboss/scripts/make_umap.py
+++ b/bedboss/scripts/make_umap.py
@@ -12,17 +12,16 @@ from sklearn.manifold import TSNE
 
 import matplotlib.pyplot as plt
 import seaborn as sns
-from typing import Union
+from typing import Optional, Union
 import warnings
-from functools import lru_cache
 
 import joblib
 from bbconf import BedBaseAgent
-from bbconf.db_utils import Bed, BedMetadata, BedStats
-from sqlalchemy.orm import Session, joinedload, load_only
+from bbconf.db_utils import Bed, BedStats
+from sqlalchemy.orm import Session, joinedload
 import json
 
-from bedboss.const import PKG_NAME
+from bedboss.const import DB_QUERY_BATCH_SIZE, PKG_NAME, TIER1_COLUMNS, TIER2_COLUMNS
 
 _LOGGER = logging.getLogger(PKG_NAME)
 
@@ -34,6 +33,25 @@ class umapReturn(BaseModel):
     dataframe: pd.DataFrame
 
     model_config = ConfigDict(arbitrary_types_allowed=True)
+
+
+class BedDbMetadata(BaseModel):
+    """Schema for per-file metadata fetched from PostgreSQL."""
+
+    id: str
+    number_of_regions: Optional[float] = None
+    mean_region_width: Optional[float] = None
+    gc_content: Optional[float] = None
+    median_tss_dist: Optional[float] = None
+    antibody: Optional[str] = None
+    library_source: Optional[str] = None
+    original_file_name: Optional[str] = None
+    global_sample_id: Optional[str] = None
+    global_experiment_id: Optional[str] = None
+    bed_compliance: Optional[str] = None
+    data_format: Optional[str] = None
+
+    model_config = ConfigDict(from_attributes=True)
 
 
 def save_umap_model(umap_model: Union[UMAP, PCA, TSNE], model_path: str) -> None:
@@ -64,18 +82,11 @@ def fetch_data(agent: BedBaseAgent) -> pd.DataFrame:
 
     _LOGGER.info("Fetching data from Qdrant...")
 
-    qdrant_host = agent.config.config.qdrant.host
-    if qdrant_host.startswith("http://") or qdrant_host.startswith("https://"):
-        client = QdrantClient(
-            url=qdrant_host,
-            api_key=agent.config.config.qdrant.api_key,
-        )
-    else:
-        client = QdrantClient(
-            host=qdrant_host,
-            port=6333,
-            api_key=agent.config.config.qdrant.api_key,
-        )
+    client = QdrantClient(
+        url=agent.config.config.qdrant.host,
+        port=agent.config.config.qdrant.port,
+        api_key=agent.config.config.qdrant.api_key,
+    )
 
     points = []
     next_offset = 0
@@ -113,10 +124,9 @@ def fetch_db_metadata(agent: BedBaseAgent, bed_ids: list[str]) -> pd.DataFrame:
     _LOGGER.info(f"Fetching DB metadata for {len(bed_ids)} beds...")
 
     rows = []
-    batch_size = 5000
     with Session(agent.config.db_engine.engine) as session:
-        for i in range(0, len(bed_ids), batch_size):
-            batch = bed_ids[i : i + batch_size]
+        for i in range(0, len(bed_ids), DB_QUERY_BATCH_SIZE):
+            batch = bed_ids[i : i + DB_QUERY_BATCH_SIZE]
             for bed_obj in (
                 session.query(Bed)
                 .options(
@@ -131,38 +141,46 @@ def fetch_db_metadata(agent: BedBaseAgent, bed_ids: list[str]) -> pd.DataFrame:
                 .filter(Bed.id.in_(batch))
                 .all()
             ):
-                row = {"id": bed_obj.id}
-
-                # Stats (tier 1 region characteristics + tier 2 TSS distance)
-                if bed_obj.stats:
-                    stats = bed_obj.stats
-                    row["number_of_regions"] = stats.number_of_regions
-                    row["mean_region_width"] = stats.mean_region_width
-                    row["gc_content"] = stats.gc_content
-                    row["median_tss_dist"] = stats.median_tss_dist
-
-                # Annotation (tier 2 fields not in Qdrant payload)
-                if bed_obj.annotations:
-                    anno = bed_obj.annotations
-                    row["antibody"] = anno.antibody
-                    row["library_source"] = anno.library_source
-                    row["original_file_name"] = anno.original_file_name
-                    row["global_sample_id"] = (
-                        ";".join(anno.global_sample_id)
-                        if anno.global_sample_id
+                meta = BedDbMetadata(
+                    id=bed_obj.id,
+                    number_of_regions=(
+                        bed_obj.stats.number_of_regions if bed_obj.stats else None
+                    ),
+                    mean_region_width=(
+                        bed_obj.stats.mean_region_width if bed_obj.stats else None
+                    ),
+                    gc_content=(bed_obj.stats.gc_content if bed_obj.stats else None),
+                    median_tss_dist=(
+                        bed_obj.stats.median_tss_dist if bed_obj.stats else None
+                    ),
+                    antibody=(
+                        bed_obj.annotations.antibody if bed_obj.annotations else None
+                    ),
+                    library_source=(
+                        bed_obj.annotations.library_source
+                        if bed_obj.annotations
                         else None
-                    )
-                    row["global_experiment_id"] = (
-                        ";".join(anno.global_experiment_id)
-                        if anno.global_experiment_id
+                    ),
+                    original_file_name=(
+                        bed_obj.annotations.original_file_name
+                        if bed_obj.annotations
                         else None
-                    )
-
-                # Classification (from Bed table)
-                row["bed_compliance"] = bed_obj.bed_compliance
-                row["data_format"] = bed_obj.data_format
-
-                rows.append(row)
+                    ),
+                    global_sample_id=(
+                        ";".join(bed_obj.annotations.global_sample_id)
+                        if bed_obj.annotations and bed_obj.annotations.global_sample_id
+                        else None
+                    ),
+                    global_experiment_id=(
+                        ";".join(bed_obj.annotations.global_experiment_id)
+                        if bed_obj.annotations
+                        and bed_obj.annotations.global_experiment_id
+                        else None
+                    ),
+                    bed_compliance=bed_obj.bed_compliance,
+                    data_format=bed_obj.data_format,
+                )
+                rows.append(meta.model_dump())
 
     df = pd.DataFrame(rows)
     if not df.empty:
@@ -241,7 +259,6 @@ def save_parquet_tiers(
       - hg38_geometry.parquet  (x, y, id)
       - hg38_meta_t1.parquet   (core biological annotation + region stats)
       - hg38_meta_t2.parquet   (extended annotation)
-      - hg38_meta_t3.parquet   (genomic partition frequencies)
     """
     os.makedirs(output_dir, exist_ok=True)
 
@@ -273,41 +290,14 @@ def save_parquet_tiers(
         _LOGGER.info("No coordinates found, skipping geometry file.")
 
     # --- Tier 1: Core metadata ---
-    t1_cols = [
-        "id",
-        "name",
-        "description",
-        "assay",
-        "target",
-        "cell_line",
-        "cell_type",
-        "tissue",
-        "number_of_regions",
-        "mean_region_width",
-        "gc_content",
-    ]
-    t1 = combined[[c for c in t1_cols if c in combined.columns]].copy()
+    t1 = combined[[c for c in TIER1_COLUMNS if c in combined.columns]].copy()
     str_cols = t1.select_dtypes(include="object").columns
     t1[str_cols] = t1[str_cols].fillna("")
     t1.to_parquet(os.path.join(output_dir, "hg38_meta_t1.parquet"), index=False)
     _LOGGER.info(f"Tier 1: {len(t1)} rows, {len(t1.columns)} columns")
 
     # --- Tier 2: Extended annotation ---
-    t2_cols = [
-        "id",
-        "treatment",
-        "antibody",
-        "species_name",
-        "genome_alias",
-        "bed_compliance",
-        "data_format",
-        "median_tss_dist",
-        "library_source",
-        "global_sample_id",
-        "global_experiment_id",
-        "original_file_name",
-    ]
-    t2 = combined[[c for c in t2_cols if c in combined.columns]].copy()
+    t2 = combined[[c for c in TIER2_COLUMNS if c in combined.columns]].copy()
     str_cols = t2.select_dtypes(include="object").columns
     t2[str_cols] = t2[str_cols].fillna("")
     t2.to_parquet(os.path.join(output_dir, "hg38_meta_t2.parquet"), index=False)
@@ -437,6 +427,41 @@ def plot_umap(value, label, name="default") -> None:
     )
 
 
+def update_umap_metadata(
+    bbconf: str,
+    output_dir: str,
+    geometry: str = None,
+) -> None:
+    """
+    Update UMAP metadata Parquet tiers without regenerating geometry.
+
+    :param bbconf: string containing bedbase configuration file path
+    :param output_dir: Directory to write Parquet tier files
+    :param geometry: Path to existing geometry Parquet (to read bed IDs).
+        If not provided, fetches IDs from Qdrant.
+    """
+    if isinstance(bbconf, str):
+        agent = BedBaseAgent(config=bbconf)
+    elif isinstance(bbconf, BedBaseAgent):
+        agent = bbconf
+    else:
+        raise TypeError(
+            "bbconf must be either a string path or a BedBaseAgent instance."
+        )
+
+    if geometry:
+        geo_df = pd.read_parquet(geometry)
+        bed_ids = list(geo_df["id"])
+        qdrant_df = fetch_data(agent=agent)
+        qdrant_df = qdrant_df.loc[qdrant_df.index.isin(bed_ids)]
+    else:
+        qdrant_df = fetch_data(agent=agent)
+        bed_ids = list(qdrant_df.index)
+
+    db_meta = fetch_db_metadata(agent, bed_ids)
+    save_parquet_tiers(qdrant_df, db_meta, output_dir)
+
+
 def get_embeddings(
     bbconf: str,
     output_file: str,
@@ -447,6 +472,7 @@ def get_embeddings(
     top_cell_lines: Union[int, None] = 15,
     save_model: bool = True,
     method: str = "umap",
+    save_parquet: bool = True,
 ) -> None:
     """
     Get embeddings from Qdrant and create UMAP, PCA, or t-SNE, and save the results to a JSON file, and optionally plot the embeddings.
@@ -463,6 +489,8 @@ def get_embeddings(
 
     :param save_model: Whether to save the model or not [Default is True]
     :param method: Dimensionality reduction method to use. Options: "umap", "pca", or "tsne" [Default is "umap"]
+
+    :param save_parquet: Whether to save Parquet tier files alongside JSON [Default is True]
 
     :return: None
 
@@ -552,15 +580,16 @@ def get_embeddings(
     save_df_as_json(umap_return.dataframe, output_file)
 
     # Parquet tiered output
-    parquet_dir = os.path.dirname(os.path.abspath(output_file))
-    try:
-        db_meta = fetch_db_metadata(agent, list(umap_return.dataframe.index))
-    except Exception as e:
-        _LOGGER.warning(
-            f"Failed to fetch DB metadata, Parquet tiers will lack stats/annotation: {e}"
-        )
-        db_meta = pd.DataFrame()
-    save_parquet_tiers(umap_return.dataframe, db_meta, parquet_dir)
+    if save_parquet:
+        parquet_dir = os.path.dirname(os.path.abspath(output_file))
+        try:
+            db_meta = fetch_db_metadata(agent, list(umap_return.dataframe.index))
+        except Exception as e:
+            _LOGGER.warning(
+                f"Failed to fetch DB metadata, Parquet tiers will lack stats/annotation: {e}"
+            )
+            db_meta = pd.DataFrame()
+        save_parquet_tiers(umap_return.dataframe, db_meta, parquet_dir)
 
     if save_model:
         ## controls the random initialization and stochastic optimization during UMAP fitting. But removing, because it causes issues during saving/loading


### PR DESCRIPTION
## Summary

- Separates UMAP data into geometry + 2 metadata tiers as Parquet files, alongside the existing 16MB JSON
- Adds `update-umap-metadata` CLI command to regenerate metadata without recomputing UMAP coordinates
- Legacy JSON still generated unchanged for backward compatibility
- PostgreSQL queries batched (5K IDs) with graceful fallback if DB is unreachable

## Motivation

The current UMAP JSON (`hg38_umap_3_13.json`) bundles geometry with a limited metadata subset (name, description, assay, cell_line). This means:
- Metadata corrections require full UMAP regeneration
- `target`, `tissue`, `cell_type`, region stats are available in Qdrant/PostgreSQL but not exposed
- 16MB uncompressed JSON is large for a static download

See [discussion #77](https://github.com/databio/lab.databio.org/discussions/77) — `same_target` is the strongest predictor of embedding similarity (-0.144 coefficient) but isn't in the current UMAP data.

## New output files

| File | Contents | Est. size | Load behavior |
|------|----------|-----------|---------------|
| `hg38_geometry.parquet` | id, x, y | ~1.7MB | Always |
| `hg38_meta_t1.parquet` | name, description, assay, target, cell_line, cell_type, tissue, number_of_regions, mean_region_width, gc_content | ~2.7MB | Always (default) |
| `hg38_meta_t2.parquet` | treatment, antibody, species_name, genome_alias, bed_compliance, data_format, median_tss_dist, library_source, global_sample_id, global_experiment_id, original_file_name | ~1-2MB | On demand |

Default load (geometry + tier 1): **~4.4MB** vs **16MB** today, with **13 columns** instead of **7**.

Tier 3 is reserved for future analysis results (gtars genomic distributions, enrichment profiles, embedding quality scores) and is not generated in this version.

## Data sources

- **Geometry + Tier 1 biological fields**: Qdrant (already fetched by existing `fetch_data()`, fields were just discarded at save time)
- **Tier 1 region stats + Tier 2**: PostgreSQL via `fetch_db_metadata()` (new, batched queries against `bed`, `bed_stats`, `bed_metadata` tables)

## Test plan

- [ ] Run `bedboss download-umap` against a config with both Qdrant and PostgreSQL access
- [ ] Verify 3 Parquet files are produced alongside legacy JSON
- [ ] Verify legacy JSON output is identical to current
- [ ] Verify `bedboss update-umap-metadata` regenerates tiers without touching geometry
- [ ] Verify graceful fallback when PostgreSQL is unreachable (Parquet files written with Qdrant-only data)

🤖 Generated with [Claude Code](https://claude.com/claude-code)